### PR TITLE
Separate item rendering

### DIFF
--- a/src/main/java/com/gedorinku/frostedglass/client/renderer/FrostedGlassBlockRenderer.java
+++ b/src/main/java/com/gedorinku/frostedglass/client/renderer/FrostedGlassBlockRenderer.java
@@ -97,7 +97,7 @@ public class FrostedGlassBlockRenderer {
         TextureUtil.initTexture(null, width, height);
     }
 
-    private enum BlurDirection {
+    public enum BlurDirection {
         VERTICAL_AND_HORIZONTAL(0),
         VERTICAL(1),
         HORIZONTAL(2);
@@ -174,10 +174,7 @@ public class FrostedGlassBlockRenderer {
             chunkOffsetUniform.set(Vector3f.ZERO);
         }
 
-        var blurDirectionUniform = shaderinstance.getUniform(BLUR_DIRECTION);
-        if (blurDirectionUniform != null) {
-            blurDirectionUniform.set(BlurDirection.VERTICAL_AND_HORIZONTAL.shaderEnum);
-        }
+        setBlurDirection(shaderinstance, BlurDirection.VERTICAL_AND_HORIZONTAL);
     }
 
     private void setupRenderState(RenderType renderType, PoseStack poseStack, Matrix4f projection, @Nullable BlurDirection blurDirection) {
@@ -234,12 +231,16 @@ public class FrostedGlassBlockRenderer {
             windowSizeUniform.set(width, height);
         }
 
-        var blurDirectionUniform = shaderinstance.getUniform(BLUR_DIRECTION);
-        if (blurDirectionUniform != null && blurDirection != null) {
-            blurDirectionUniform.set(blurDirection.shaderEnum);
-        }
+        setBlurDirection(shaderinstance, blurDirection);
 
         RenderSystem.setupShaderLights(shaderinstance);
         shaderinstance.apply();
+    }
+
+    public static void setBlurDirection(ShaderInstance shaderInstance, BlurDirection blurDirection) {
+        var blurDirectionUniform = shaderInstance.getUniform(BLUR_DIRECTION);
+        if (blurDirectionUniform != null && blurDirection != null) {
+            blurDirectionUniform.set(blurDirection.shaderEnum);
+        }
     }
 }

--- a/src/main/java/com/gedorinku/frostedglass/mixin/client/renderer/ItemRendererMixin.java
+++ b/src/main/java/com/gedorinku/frostedglass/mixin/client/renderer/ItemRendererMixin.java
@@ -58,6 +58,10 @@ public abstract class ItemRendererMixin {
         for (var dir : new FrostedGlassBlockRenderer.BlurDirection[]{FrostedGlassBlockRenderer.BlurDirection.VERTICAL, FrostedGlassBlockRenderer.BlurDirection.HORIZONTAL}) {
             FrostedGlassBlockRenderer.setBlurDirection(shaderInstance, dir);
             render(itemStack, transformType, p_174246_, poseStack, multiBufferSource, p_174250_, p_174251_, bakedModel);
+
+            if (multiBufferSource instanceof MultiBufferSource.BufferSource) {
+                ((MultiBufferSource.BufferSource) multiBufferSource).endBatch(FrostedGlassBlockRenderer.RENDER_TYPE);
+            }
         }
 
         FrostedGlassBlockRenderer.setBlurDirection(shaderInstance, FrostedGlassBlockRenderer.BlurDirection.VERTICAL_AND_HORIZONTAL);

--- a/src/main/java/com/gedorinku/frostedglass/mixin/client/renderer/ItemRendererMixin.java
+++ b/src/main/java/com/gedorinku/frostedglass/mixin/client/renderer/ItemRendererMixin.java
@@ -1,0 +1,67 @@
+package com.gedorinku.frostedglass.mixin.client.renderer;
+
+import com.gedorinku.frostedglass.FrostedGlassMod;
+import com.gedorinku.frostedglass.client.renderer.FrostedGlassBlockRenderer;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+
+@Mixin(ItemRenderer.class)
+public abstract class ItemRendererMixin {
+
+    @Shadow
+    public abstract void render(ItemStack p_115144_, ItemTransforms.TransformType p_115145_, boolean p_115146_, PoseStack p_115147_, MultiBufferSource p_115148_, int p_115149_, int p_115150_, BakedModel p_115151_);
+
+    @Shadow
+    public abstract BakedModel getModel(ItemStack p_174265_, @org.jetbrains.annotations.Nullable Level p_174266_, @org.jetbrains.annotations.Nullable LivingEntity p_174267_, int p_174268_);
+
+    @Inject(
+            method = "renderStatic(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/client/renderer/block/model/ItemTransforms$TransformType;ZLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/level/Level;III)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void renderStatic(
+            @Nullable LivingEntity livingEntity,
+            ItemStack itemStack,
+            ItemTransforms.TransformType transformType,
+            boolean p_174246_,
+            PoseStack poseStack,
+            MultiBufferSource multiBufferSource,
+            Level level,
+            int p_174250_,
+            int p_174251_,
+            int p_174252_,
+            CallbackInfo ci
+    ) {
+        RenderType renderType = ItemBlockRenderTypes.getRenderType(itemStack, false);
+        if (renderType != FrostedGlassBlockRenderer.RENDER_TYPE) {
+            return;
+        }
+
+        var bakedModel = getModel(itemStack, level, livingEntity, p_174252_);
+        var shaderInstance = FrostedGlassMod.RENDER_TYPE_FROSTED_GLASS_SHADER;
+
+        for (var dir : new FrostedGlassBlockRenderer.BlurDirection[]{FrostedGlassBlockRenderer.BlurDirection.VERTICAL, FrostedGlassBlockRenderer.BlurDirection.HORIZONTAL}) {
+            FrostedGlassBlockRenderer.setBlurDirection(shaderInstance, dir);
+            render(itemStack, transformType, p_174246_, poseStack, multiBufferSource, p_174250_, p_174251_, bakedModel);
+        }
+
+        FrostedGlassBlockRenderer.setBlurDirection(shaderInstance, FrostedGlassBlockRenderer.BlurDirection.VERTICAL_AND_HORIZONTAL);
+
+        ci.cancel();
+    }
+}

--- a/src/main/resources/assets/frostedglass/shaders/core/frosted_glass/frosted_glass.fsh
+++ b/src/main/resources/assets/frostedglass/shaders/core/frosted_glass/frosted_glass.fsh
@@ -37,7 +37,7 @@ void main() {
 
     int radius = int(3 * stdDev);
     int diamerter = 2 * radius;
-    // 手に持ったときや GUI に表示するときだけガウシアンブラーを2回に分ける実装ができていないので、とりあえず雑に品質を落としている。
+    // GUI に表示するときなどガウシアンブラーを2回に分ける実装が一部できていないので、とりあえず雑に品質を落としている。
     int sampleSize = BlurDirection == VERTICAL_AND_HORIZONTAL ? diamerter / 4 : diamerter / 2;
     float step = float(diamerter) / max(1.0, sampleSize - 1.0);
     float sum = 0.0;

--- a/src/main/resources/frostedglass.mixins.json
+++ b/src/main/resources/frostedglass.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [],
   "client": [
     "client.renderer.ItemBlockRenderTypesMixin",
+    "client.renderer.ItemRendererMixin",
     "client.renderer.LevelRendererMixin",
     "client.renderer.RenderTypeMixin"
   ],


### PR DESCRIPTION
https://github.com/gedorinku/frosted-glass/issues/4

手に持ったすりガラスのガウシアンブラーを、縦方向と横方向の2回に分けて描画するようにした。

フレームレートが  216fps -> 261fps になった。

<details>
<summary> Before </summary>

```
---- Minecraft Profiler Results ----
// Speedy. Zoooooom!

Version: 1.18.2
Time span: 10003 ms
Tick span: 2165 ticks
// This is approximately 216.42 ticks per second. It should be 20 ticks per second

--- BEGIN PROFILE DUMP ---

[00] gameRenderer(2165/1) - 48.54%/48.54%
[01] |   level(2165/1) - 85.13%/41.32%
[02] |   |   terrain(2165/1) - 46.09%/19.04%
[03] |   |   |   render_RenderType[solid:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4650/0x00000008016e48e0@72e6e93]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2165/1) - 38.98%/7.42%
[03] |   |   |   render_RenderType[cutout:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=false)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4652/0x00000008016e4d10@32c29f7b]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2165/1) - 32.26%/6.14%
[03] |   |   |   render_RenderType[cutout_mipped:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4651/0x00000008016e4af8@2fbe0960]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2165/1) - 24.89%/4.74%
[03] |   |   |   unspecified(2165/1) - 3.77%/0.72%
[03] |   |   |   filterempty(6495/3) - 0.10%/0.02%
[02] |   |   translucent(2165/1) - 23.21%/9.59%
[03] |   |   |   render_RenderType[translucent:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4653/0x00000008016e4f28@17746fcb]], translucent_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, translucent_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2165/1) - 60.66%/5.82%
[03] |   |   |   frostedglass:frostedGlassChunkLayer(2165/1) - 33.27%/3.19%
[04] |   |   |   |   unspecified(2165/1) - 82.09%/2.62%
[04] |   |   |   |   frostedglass:setTextureStateBeforeRender(4330/2) - 17.91%/0.57%
[05] |   |   |   |   |   frostedglass:glCopyTexSubImage2D(4330/2) - 87.66%/0.50%
[05] |   |   |   |   |   unspecified(4330/2) - 12.34%/0.07%
[03] |   |   |   unspecified(2165/1) - 5.94%/0.57%
[03] |   |   |   filterempty(2165/1) - 0.07%/0.01%
[03] |   |   |   translucent_sort(2165/1) - 0.05%/0.00%
[02] |   |   entities(2165/1) - 10.34%/4.27%
[02] |   |   blockentities(2165/1) - 2.96%/1.22%
[02] |   |   hand(2165/1) - 2.75%/1.13%
[03] |   |   |   unspecified(2165/1) - 76.40%/0.87%
[03] |   |   |   frostedglass:setTextureStateBeforeRender(2165/1) - 23.60%/0.27%
[04] |   |   |   |   frostedglass:glCopyTexSubImage2D(2165/1) - 88.68%/0.24%
[04] |   |   |   |   unspecified(2165/1) - 11.32%/0.03%
[02] |   |   sky(2165/1) - 2.65%/1.10%
[02] |   |   string(2165/1) - 2.57%/1.06%
[03] |   |   |   render_RenderType[tripwire:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4688/0x00000008016e9920@635ad140]], translucent_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, weather_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2165/1) - 81.61%/0.87%
[03] |   |   |   unspecified(2165/1) - 17.88%/0.19%
[03] |   |   |   filterempty(2165/1) - 0.51%/0.01%
[02] |   |   compilechunks(2165/1) - 2.12%/0.88%
[03] |   |   |   populate_chunks_to_compile(2165/1) - 94.52%/0.83%
[03] |   |   |   unspecified(2165/1) - 3.95%/0.03%
[03] |   |   |   upload(2165/1) - 0.92%/0.01%
[03] |   |   |   schedule_async_compile(2165/1) - 0.60%/0.01%
[02] |   |   particles(2165/1) - 1.98%/0.82%
[02] |   |   clear(2165/1) - 1.31%/0.54%
[02] |   |   unspecified(2165/1) - 1.20%/0.50%
[02] |   |   clouds(2165/1) - 0.80%/0.33%
[02] |   |   outline(2165/1) - 0.58%/0.24%
[02] |   |   pick(2165/1) - 0.42%/0.17%
[03] |   |   |   #getEntities 2165/1
[02] |   |   terrain_setup(2165/1) - 0.26%/0.11%
[03] |   |   |   unspecified(2165/1) - 37.79%/0.04%
[03] |   |   |   culling(2165/1) - 27.83%/0.03%
[03] |   |   |   update(2165/1) - 18.39%/0.02%
[03] |   |   |   camera(2165/1) - 10.33%/0.01%
[03] |   |   |   cull(2165/1) - 5.67%/0.01%
[02] |   |   camera(2165/1) - 0.23%/0.10%
[02] |   |   light_updates(2165/1) - 0.18%/0.07%
[02] |   |   lightTex(201/0) - 0.11%/0.04%
[02] |   |   fog(2165/1) - 0.08%/0.03%
[02] |   |   weather(2165/1) - 0.05%/0.02%
[02] |   |   destroyProgress(2165/1) - 0.04%/0.02%
[02] |   |   light_update_queue(2165/1) - 0.03%/0.01%
[02] |   |   forge_render_last(2165/1) - 0.02%/0.01%
[02] |   |   culling(2165/1) - 0.01%/0.01%
[02] |   |   captureFrustum(2165/1) - 0.01%/0.01%
[02] |   |   center(2165/1) - 0.01%/0.00%
[01] |   gui(2165/1) - 14.80%/7.18%
[02] |   |   unspecified(2165/1) - 69.56%/5.00%
[02] |   |   chat(2165/1) - 22.94%/1.65%
[02] |   |   frostedglass:setTextureStateBeforeRender(4330/2) - 7.05%/0.51%
[03] |   |   |   frostedglass:glCopyTexSubImage2D(4330/2) - 85.77%/0.43%
[03] |   |   |   unspecified(4330/2) - 14.23%/0.07%
[02] |   |   forgeHudText(2165/1) - 0.30%/0.02%
[02] |   |   bossHealth(2165/1) - 0.11%/0.01%
[02] |   |   selectedItemName(2165/1) - 0.04%/0.00%
[01] |   unspecified(2165/1) - 0.07%/0.04%
[00] updateDisplay(2165/1) - 43.83%/43.83%
[00] tick(2165/1) - 4.81%/4.81%
[01] |   #clientTick 201/0
[01] |   level(201/0) - 71.40%/3.43%
[02] |   |   entities(201/0) - 94.02%/3.23%
[03] |   |   |   minecraft:creeper(4482/2) - 9.90%/0.32%
[04] |   |   |   |   unspecified(4482/2) - 48.34%/0.15%
[04] |   |   |   |   entityBaseTick(4482/2) - 14.37%/0.05%
[04] |   |   |   |   push(4482/2) - 9.90%/0.03%
[05] |   |   |   |   |   #getEntities 4482/2
[04] |   |   |   |   livingEntityBaseTick(4482/2) - 9.31%/0.03%
[04] |   |   |   |   freezing(4482/2) - 6.18%/0.02%
[04] |   |   |   |   headTurn(4482/2) - 2.72%/0.01%
[04] |   |   |   |   travel(4482/2) - 2.10%/0.01%
[04] |   |   |   |   mobBaseTick(4482/2) - 1.86%/0.01%
[04] |   |   |   |   ai(4482/2) - 1.52%/0.00%
[04] |   |   |   |   looting(4482/2) - 1.29%/0.00%
[04] |   |   |   |   jump(4482/2) - 1.22%/0.00%
[04] |   |   |   |   rangeChecks(4482/2) - 1.20%/0.00%
[03] |   |   |   minecraft:zombie(4078/2) - 9.51%/0.31%
[04] |   |   |   |   unspecified(4078/2) - 45.10%/0.14%
[04] |   |   |   |   entityBaseTick(4078/2) - 15.80%/0.05%
[04] |   |   |   |   livingEntityBaseTick(4078/2) - 11.32%/0.03%
[04] |   |   |   |   push(4078/2) - 8.61%/0.03%
[05] |   |   |   |   |   #getEntities 4078/1
[04] |   |   |   |   freezing(4078/2) - 6.82%/0.02%
[04] |   |   |   |   headTurn(4078/2) - 2.58%/0.01%
[04] |   |   |   |   mobBaseTick(4078/2) - 2.34%/0.01%
[04] |   |   |   |   travel(4078/2) - 2.26%/0.01%
[04] |   |   |   |   ai(4078/2) - 1.53%/0.00%
[04] |   |   |   |   looting(4078/2) - 1.27%/0.00%
[04] |   |   |   |   rangeChecks(4078/2) - 1.19%/0.00%
[04] |   |   |   |   jump(4078/2) - 1.18%/0.00%
[03] |   |   |   minecraft:cow(3819/2) - 8.73%/0.28%
[04] |   |   |   |   unspecified(3819/2) - 38.96%/0.11%
[04] |   |   |   |   entityBaseTick(3819/2) - 22.46%/0.06%
[04] |   |   |   |   livingEntityBaseTick(3819/2) - 11.52%/0.03%
[04] |   |   |   |   push(3819/2) - 8.81%/0.02%
[05] |   |   |   |   |   #getEntities 3819/1
[04] |   |   |   |   freezing(3819/2) - 6.57%/0.02%
[04] |   |   |   |   headTurn(3819/2) - 2.58%/0.01%
[04] |   |   |   |   mobBaseTick(3819/2) - 2.09%/0.01%
[04] |   |   |   |   travel(3819/2) - 2.05%/0.01%
[04] |   |   |   |   ai(3819/2) - 1.37%/0.00%
[04] |   |   |   |   looting(3819/2) - 1.22%/0.00%
[04] |   |   |   |   rangeChecks(3819/2) - 1.20%/0.00%
[04] |   |   |   |   jump(3819/2) - 1.17%/0.00%
[03] |   |   |   minecraft:skeleton(3896/2) - 8.52%/0.28%
[04] |   |   |   |   unspecified(3896/2) - 45.64%/0.13%
[04] |   |   |   |   entityBaseTick(3896/2) - 15.38%/0.04%
[04] |   |   |   |   livingEntityBaseTick(3896/2) - 11.70%/0.03%
[04] |   |   |   |   push(3896/2) - 8.65%/0.02%
[05] |   |   |   |   |   #getEntities 3896/1
[04] |   |   |   |   freezing(3896/2) - 6.48%/0.02%
[04] |   |   |   |   headTurn(3896/2) - 2.68%/0.01%
[04] |   |   |   |   mobBaseTick(3896/2) - 2.12%/0.01%
[04] |   |   |   |   travel(3896/2) - 2.04%/0.01%
[04] |   |   |   |   ai(3896/2) - 1.50%/0.00%
[04] |   |   |   |   looting(3896/2) - 1.34%/0.00%
[04] |   |   |   |   rangeChecks(3896/2) - 1.26%/0.00%
[04] |   |   |   |   jump(3896/2) - 1.22%/0.00%
[03] |   |   |   minecraft:pig(3618/2) - 8.13%/0.26%
[04] |   |   |   |   unspecified(3618/2) - 40.88%/0.11%
[04] |   |   |   |   entityBaseTick(3618/2) - 17.61%/0.05%
[04] |   |   |   |   livingEntityBaseTick(3618/2) - 12.74%/0.03%
[04] |   |   |   |   push(3618/2) - 9.03%/0.02%
[05] |   |   |   |   |   #getEntities 3618/1
[04] |   |   |   |   freezing(3618/2) - 6.48%/0.02%
[04] |   |   |   |   travel(3618/2) - 2.88%/0.01%
[04] |   |   |   |   headTurn(3618/2) - 2.79%/0.01%
[04] |   |   |   |   mobBaseTick(3618/2) - 2.15%/0.01%
[04] |   |   |   |   ai(3618/2) - 1.55%/0.00%
[04] |   |   |   |   looting(3618/2) - 1.35%/0.00%
[04] |   |   |   |   rangeChecks(3618/2) - 1.33%/0.00%
[04] |   |   |   |   jump(3618/2) - 1.22%/0.00%
[03] |   |   |   minecraft:player(201/0) - 7.26%/0.23%
[04] |   |   |   |   #getEntities 1005/0
[04] |   |   |   |   unspecified(201/0) - 60.06%/0.14%
[04] |   |   |   |   travel(201/0) - 23.05%/0.05%
[05] |   |   |   |   |   rest(201/0) - 37.90%/0.02%
[05] |   |   |   |   |   unspecified(201/0) - 32.24%/0.02%
[05] |   |   |   |   |   move(201/0) - 29.86%/0.02%
[06] |   |   |   |   |   |   #getEntities 201/0
[04] |   |   |   |   livingEntityBaseTick(201/0) - 5.47%/0.01%
[04] |   |   |   |   entityBaseTick(201/0) - 4.69%/0.01%
[04] |   |   |   |   ai(201/0) - 2.64%/0.01%
[05] |   |   |   |   |   unspecified(201/0) - 67.15%/0.00%
[05] |   |   |   |   |   newAi(201/0) - 32.85%/0.00%
[04] |   |   |   |   push(201/0) - 1.74%/0.00%
[05] |   |   |   |   |   #getEntities 201/0
[04] |   |   |   |   freezing(201/0) - 1.38%/0.00%
[04] |   |   |   |   headTurn(201/0) - 0.67%/0.00%
[04] |   |   |   |   jump(201/0) - 0.16%/0.00%
[04] |   |   |   |   rangeChecks(201/0) - 0.13%/0.00%
[03] |   |   |   minecraft:squid(1502/1) - 6.36%/0.21%
[04] |   |   |   |   unspecified(1502/1) - 34.21%/0.07%
[04] |   |   |   |   travel(1502/1) - 26.82%/0.06%
[05] |   |   |   |   |   rest(1502/1) - 45.74%/0.03%
[05] |   |   |   |   |   move(1502/1) - 36.57%/0.02%
[06] |   |   |   |   |   |   #getEntities 1502/0
[05] |   |   |   |   |   unspecified(1502/1) - 17.68%/0.01%
[04] |   |   |   |   entityBaseTick(1502/1) - 17.72%/0.04%
[04] |   |   |   |   livingEntityBaseTick(1502/1) - 7.60%/0.02%
[04] |   |   |   |   push(1502/1) - 4.00%/0.01%
[05] |   |   |   |   |   #getEntities 1502/0
[04] |   |   |   |   freezing(1502/1) - 2.97%/0.01%
[04] |   |   |   |   headTurn(1502/1) - 1.98%/0.00%
[04] |   |   |   |   mobBaseTick(1502/1) - 1.44%/0.00%
[04] |   |   |   |   ai(1502/1) - 1.18%/0.00%
[04] |   |   |   |   looting(1502/1) - 0.74%/0.00%
[04] |   |   |   |   jump(1502/1) - 0.68%/0.00%
[04] |   |   |   |   rangeChecks(1502/1) - 0.67%/0.00%
[03] |   |   |   minecraft:chicken(2814/1) - 6.03%/0.19%
[04] |   |   |   |   unspecified(2814/1) - 44.60%/0.09%
[04] |   |   |   |   entityBaseTick(2814/1) - 14.68%/0.03%
[04] |   |   |   |   livingEntityBaseTick(2814/1) - 12.30%/0.02%
[04] |   |   |   |   push(2814/1) - 9.68%/0.02%
[05] |   |   |   |   |   #getEntities 2814/1
[04] |   |   |   |   freezing(2814/1) - 5.68%/0.01%
[04] |   |   |   |   headTurn(2814/1) - 2.85%/0.01%
[04] |   |   |   |   mobBaseTick(2814/1) - 2.41%/0.00%
[04] |   |   |   |   travel(2814/1) - 2.31%/0.00%
[04] |   |   |   |   ai(2814/1) - 1.51%/0.00%
[04] |   |   |   |   looting(2814/1) - 1.37%/0.00%
[04] |   |   |   |   rangeChecks(2814/1) - 1.30%/0.00%
[04] |   |   |   |   jump(2814/1) - 1.30%/0.00%
[03] |   |   |   unspecified(201/0) - 5.96%/0.19%
[03] |   |   |   minecraft:glow_squid(1341/1) - 5.08%/0.16%
[04] |   |   |   |   unspecified(1341/1) - 42.67%/0.07%
[04] |   |   |   |   travel(1341/1) - 22.20%/0.04%
[05] |   |   |   |   |   rest(1341/1) - 50.99%/0.02%
[05] |   |   |   |   |   move(1341/1) - 27.25%/0.01%
[06] |   |   |   |   |   |   #getEntities 1341/0
[05] |   |   |   |   |   unspecified(1341/1) - 21.75%/0.01%
[04] |   |   |   |   entityBaseTick(1341/1) - 14.56%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1341/1) - 6.81%/0.01%
[04] |   |   |   |   push(1341/1) - 4.14%/0.01%
[05] |   |   |   |   |   #getEntities 1341/0
[04] |   |   |   |   freezing(1341/1) - 3.09%/0.01%
[04] |   |   |   |   headTurn(1341/1) - 1.75%/0.00%
[04] |   |   |   |   mobBaseTick(1341/1) - 1.32%/0.00%
[04] |   |   |   |   ai(1341/1) - 1.04%/0.00%
[04] |   |   |   |   jump(1341/1) - 0.82%/0.00%
[04] |   |   |   |   looting(1341/1) - 0.81%/0.00%
[04] |   |   |   |   rangeChecks(1341/1) - 0.78%/0.00%
[03] |   |   |   minecraft:bat(2502/1) - 4.94%/0.16%
[04] |   |   |   |   unspecified(2502/1) - 51.46%/0.08%
[04] |   |   |   |   entityBaseTick(2502/1) - 13.53%/0.02%
[04] |   |   |   |   livingEntityBaseTick(2502/1) - 12.40%/0.02%
[04] |   |   |   |   freezing(2502/1) - 6.87%/0.01%
[04] |   |   |   |   headTurn(2502/1) - 3.16%/0.01%
[04] |   |   |   |   mobBaseTick(2502/1) - 2.53%/0.00%
[04] |   |   |   |   travel(2502/1) - 2.25%/0.00%
[04] |   |   |   |   push(2502/1) - 1.92%/0.00%
[04] |   |   |   |   ai(2502/1) - 1.74%/0.00%
[04] |   |   |   |   jump(2502/1) - 1.43%/0.00%
[04] |   |   |   |   rangeChecks(2502/1) - 1.40%/0.00%
[04] |   |   |   |   looting(2502/1) - 1.32%/0.00%
[03] |   |   |   minecraft:drowned(1206/1) - 3.81%/0.12%
[04] |   |   |   |   entityBaseTick(1206/1) - 37.53%/0.05%
[04] |   |   |   |   unspecified(1206/1) - 32.19%/0.04%
[04] |   |   |   |   livingEntityBaseTick(1206/1) - 9.20%/0.01%
[04] |   |   |   |   freezing(1206/1) - 5.83%/0.01%
[04] |   |   |   |   push(1206/1) - 5.52%/0.01%
[05] |   |   |   |   |   #getEntities 1206/0
[04] |   |   |   |   travel(1206/1) - 2.31%/0.00%
[04] |   |   |   |   headTurn(1206/1) - 1.99%/0.00%
[04] |   |   |   |   mobBaseTick(1206/1) - 1.68%/0.00%
[04] |   |   |   |   ai(1206/1) - 1.10%/0.00%
[04] |   |   |   |   rangeChecks(1206/1) - 0.90%/0.00%
[04] |   |   |   |   jump(1206/1) - 0.88%/0.00%
[04] |   |   |   |   looting(1206/1) - 0.87%/0.00%
[03] |   |   |   minecraft:spider(1344/1) - 3.48%/0.11%
[04] |   |   |   |   unspecified(1344/1) - 44.71%/0.05%
[04] |   |   |   |   entityBaseTick(1344/1) - 17.46%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1344/1) - 12.40%/0.01%
[04] |   |   |   |   push(1344/1) - 9.52%/0.01%
[05] |   |   |   |   |   #getEntities 1344/0
[04] |   |   |   |   freezing(1344/1) - 4.87%/0.01%
[04] |   |   |   |   headTurn(1344/1) - 2.46%/0.00%
[04] |   |   |   |   mobBaseTick(1344/1) - 2.08%/0.00%
[04] |   |   |   |   travel(1344/1) - 2.00%/0.00%
[04] |   |   |   |   ai(1344/1) - 1.34%/0.00%
[04] |   |   |   |   looting(1344/1) - 1.08%/0.00%
[04] |   |   |   |   rangeChecks(1344/1) - 1.04%/0.00%
[04] |   |   |   |   jump(1344/1) - 1.04%/0.00%
[03] |   |   |   minecraft:sheep(1407/1) - 3.46%/0.11%
[04] |   |   |   |   unspecified(1407/1) - 42.31%/0.05%
[04] |   |   |   |   entityBaseTick(1407/1) - 18.16%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1407/1) - 11.11%/0.01%
[04] |   |   |   |   push(1407/1) - 10.66%/0.01%
[05] |   |   |   |   |   #getEntities 1407/0
[04] |   |   |   |   freezing(1407/1) - 6.14%/0.01%
[04] |   |   |   |   headTurn(1407/1) - 2.54%/0.00%
[04] |   |   |   |   travel(1407/1) - 2.16%/0.00%
[04] |   |   |   |   mobBaseTick(1407/1) - 2.04%/0.00%
[04] |   |   |   |   ai(1407/1) - 1.45%/0.00%
[04] |   |   |   |   looting(1407/1) - 1.19%/0.00%
[04] |   |   |   |   rangeChecks(1407/1) - 1.14%/0.00%
[04] |   |   |   |   jump(1407/1) - 1.10%/0.00%
[03] |   |   |   minecraft:enderman(804/0) - 2.68%/0.09%
[04] |   |   |   |   unspecified(804/0) - 55.89%/0.05%
[04] |   |   |   |   entityBaseTick(804/0) - 12.72%/0.01%
[04] |   |   |   |   push(804/0) - 9.14%/0.01%
[05] |   |   |   |   |   #getEntities 804/0
[04] |   |   |   |   livingEntityBaseTick(804/0) - 8.24%/0.01%
[04] |   |   |   |   freezing(804/0) - 4.65%/0.00%
[04] |   |   |   |   headTurn(804/0) - 1.91%/0.00%
[04] |   |   |   |   travel(804/0) - 1.83%/0.00%
[04] |   |   |   |   mobBaseTick(804/0) - 1.72%/0.00%
[04] |   |   |   |   ai(804/0) - 1.25%/0.00%
[04] |   |   |   |   looting(804/0) - 0.92%/0.00%
[04] |   |   |   |   jump(804/0) - 0.90%/0.00%
[04] |   |   |   |   rangeChecks(804/0) - 0.83%/0.00%
[03] |   |   |   minecraft:horse(804/0) - 2.32%/0.07%
[04] |   |   |   |   unspecified(804/0) - 42.35%/0.03%
[04] |   |   |   |   entityBaseTick(804/0) - 19.48%/0.01%
[04] |   |   |   |   livingEntityBaseTick(804/0) - 10.57%/0.01%
[04] |   |   |   |   push(804/0) - 9.46%/0.01%
[05] |   |   |   |   |   #getEntities 804/0
[04] |   |   |   |   freezing(804/0) - 4.92%/0.00%
[04] |   |   |   |   travel(804/0) - 3.20%/0.00%
[04] |   |   |   |   ai(804/0) - 3.11%/0.00%
[04] |   |   |   |   headTurn(804/0) - 2.36%/0.00%
[04] |   |   |   |   mobBaseTick(804/0) - 1.60%/0.00%
[04] |   |   |   |   jump(804/0) - 0.99%/0.00%
[04] |   |   |   |   looting(804/0) - 0.99%/0.00%
[04] |   |   |   |   rangeChecks(804/0) - 0.98%/0.00%
[03] |   |   |   minecraft:item(1090/1) - 1.38%/0.04%
[04] |   |   |   |   unspecified(1090/1) - 38.95%/0.02%
[04] |   |   |   |   move(272/0) - 30.86%/0.01%
[05] |   |   |   |   |   #getEntities 272/0
[04] |   |   |   |   entityBaseTick(1090/1) - 16.94%/0.01%
[04] |   |   |   |   rest(272/0) - 13.25%/0.01%
[03] |   |   |   minecraft:zombie_villager(402/0) - 1.23%/0.04%
[04] |   |   |   |   unspecified(402/0) - 49.69%/0.02%
[04] |   |   |   |   push(402/0) - 12.68%/0.01%
[05] |   |   |   |   |   #getEntities 402/0
[04] |   |   |   |   entityBaseTick(402/0) - 12.63%/0.01%
[04] |   |   |   |   livingEntityBaseTick(402/0) - 8.58%/0.00%
[04] |   |   |   |   freezing(402/0) - 4.62%/0.00%
[04] |   |   |   |   mobBaseTick(402/0) - 2.58%/0.00%
[04] |   |   |   |   headTurn(402/0) - 2.33%/0.00%
[04] |   |   |   |   travel(402/0) - 2.11%/0.00%
[04] |   |   |   |   ai(402/0) - 1.57%/0.00%
[04] |   |   |   |   looting(402/0) - 1.29%/0.00%
[04] |   |   |   |   jump(402/0) - 0.98%/0.00%
[04] |   |   |   |   rangeChecks(402/0) - 0.95%/0.00%
[03] |   |   |   minecraft:armor_stand(201/0) - 0.71%/0.02%
[04] |   |   |   |   unspecified(201/0) - 48.43%/0.01%
[04] |   |   |   |   push(201/0) - 13.75%/0.00%
[05] |   |   |   |   |   #getEntities 201/0
[04] |   |   |   |   entityBaseTick(201/0) - 10.15%/0.00%
[04] |   |   |   |   livingEntityBaseTick(201/0) - 7.56%/0.00%
[04] |   |   |   |   travel(201/0) - 7.50%/0.00%
[04] |   |   |   |   freezing(201/0) - 4.98%/0.00%
[04] |   |   |   |   headTurn(201/0) - 4.13%/0.00%
[04] |   |   |   |   ai(201/0) - 1.60%/0.00%
[04] |   |   |   |   rangeChecks(201/0) - 0.95%/0.00%
[04] |   |   |   |   jump(201/0) - 0.94%/0.00%
[03] |   |   |   minecraft:chest_minecart(2010/1) - 0.52%/0.02%
[02] |   |   blockEntities(201/0) - 3.85%/0.13%
[03] |   |   |   unspecified(201/0) - 58.92%/0.08%
[03] |   |   |   minecraft:mob_spawner(5829/3) - 20.73%/0.03%
[03] |   |   |   minecraft:chest(6633/3) - 20.35%/0.03%
[02] |   |   unspecified(201/0) - 2.10%/0.07%
[02] |   |   blocks(201/0) - 0.03%/0.00%
[01] |   textures(201/0) - 13.11%/0.63%
[01] |   animateTick(201/0) - 11.68%/0.56%
[01] |   particles(201/0) - 1.50%/0.07%
[02] |   |   PARTICLE_SHEET_OPAQUE(201/0) - 53.21%/0.04%
[02] |   |   PARTICLE_SHEET_TRANSLUCENT(201/0) - 31.04%/0.02%
[02] |   |   unspecified(201/0) - 15.75%/0.01%
[01] |   unspecified(2165/1) - 0.73%/0.04%
[01] |   gameMode(201/0) - 0.47%/0.02%
[01] |   pick(201/0) - 0.40%/0.02%
[02] |   |   #getEntities 201/0
[01] |   gameRenderer(201/0) - 0.29%/0.01%
[01] |   gui(201/0) - 0.19%/0.01%
[01] |   Keybindings(201/0) - 0.15%/0.01%
[01] |   keyboard(201/0) - 0.04%/0.00%
[01] |   levelRenderer(201/0) - 0.04%/0.00%
[00] unspecified(2165/1) - 1.60%/1.60%
[00] render(2165/1) - 0.57%/0.57%
[01] |   unspecified(2165/1) - 98.89%/0.57%
[01] |   display(2165/1) - 1.11%/0.01%
[00] blit(2165/1) - 0.42%/0.42%
[00] sound(2165/1) - 0.12%/0.12%
[00] yield(2165/1) - 0.05%/0.05%
[00] scheduledExecutables(2165/1) - 0.04%/0.04%
[00] toasts(2165/1) - 0.01%/0.01%
[00] fpsUpdate(2165/1) - 0.01%/0.01%
--- END PROFILE DUMP ---

--- BEGIN COUNTER DUMP ---

-- Counter: clientTick --
[00] root total:0/201 average: 0/0
[01] |   tick total:201/201 average: 0/0


-- Counter: getEntities --
[00] root total:0/38606 average: 0/17
[01] |   tick total:0/36441 average: 0/16
[02] |   |   level total:0/36240 average: 0/16
[03] |   |   |   entities total:0/36240 average: 0/16
[04] |   |   |   |   minecraft:creeper total:0/4482 average: 0/2
[05] |   |   |   |   |   push total:4482/4482 average: 2/2
[04] |   |   |   |   minecraft:zombie total:0/4078 average: 0/1
[05] |   |   |   |   |   push total:4078/4078 average: 1/1
[04] |   |   |   |   minecraft:skeleton total:0/3896 average: 0/1
[05] |   |   |   |   |   push total:3896/3896 average: 1/1
[04] |   |   |   |   minecraft:cow total:0/3819 average: 0/1
[05] |   |   |   |   |   push total:3819/3819 average: 1/1
[04] |   |   |   |   minecraft:pig total:0/3618 average: 0/1
[05] |   |   |   |   |   push total:3618/3618 average: 1/1
[04] |   |   |   |   minecraft:squid total:0/3004 average: 0/1
[05] |   |   |   |   |   travel total:0/1502 average: 0/0
[06] |   |   |   |   |   |   move total:1502/1502 average: 0/0
[05] |   |   |   |   |   push total:1502/1502 average: 0/0
[04] |   |   |   |   minecraft:chicken total:0/2814 average: 0/1
[05] |   |   |   |   |   push total:2814/2814 average: 1/1
[04] |   |   |   |   minecraft:glow_squid total:0/2682 average: 0/1
[05] |   |   |   |   |   travel total:0/1341 average: 0/0
[06] |   |   |   |   |   |   move total:1341/1341 average: 0/0
[05] |   |   |   |   |   push total:1341/1341 average: 0/0
[04] |   |   |   |   minecraft:player total:1005/1407 average: 0/0
[05] |   |   |   |   |   travel total:0/201 average: 0/0
[06] |   |   |   |   |   |   move total:201/201 average: 0/0
[05] |   |   |   |   |   push total:201/201 average: 0/0
[04] |   |   |   |   minecraft:sheep total:0/1407 average: 0/0
[05] |   |   |   |   |   push total:1407/1407 average: 0/0
[04] |   |   |   |   minecraft:spider total:0/1344 average: 0/0
[05] |   |   |   |   |   push total:1344/1344 average: 0/0
[04] |   |   |   |   minecraft:drowned total:0/1206 average: 0/0
[05] |   |   |   |   |   push total:1206/1206 average: 0/0
[04] |   |   |   |   minecraft:enderman total:0/804 average: 0/0
[05] |   |   |   |   |   push total:804/804 average: 0/0
[04] |   |   |   |   minecraft:horse total:0/804 average: 0/0
[05] |   |   |   |   |   push total:804/804 average: 0/0
[04] |   |   |   |   minecraft:zombie_villager total:0/402 average: 0/0
[05] |   |   |   |   |   push total:402/402 average: 0/0
[04] |   |   |   |   minecraft:item total:0/272 average: 0/0
[05] |   |   |   |   |   move total:272/272 average: 0/0
[04] |   |   |   |   minecraft:armor_stand total:0/201 average: 0/0
[05] |   |   |   |   |   push total:201/201 average: 0/0
[02] |   |   pick total:201/201 average: 0/0
[01] |   gameRenderer total:0/2165 average: 0/1
[02] |   |   level total:0/2165 average: 0/1
[03] |   |   |   pick total:2165/2165 average: 1/1


--- END COUNTER DUMP ---


```

</details>

<details>
<summary> After </summary>

```
---- Minecraft Profiler Results ----
// I'd Rather Be Surfing

Version: 1.18.2
Time span: 10000 ms
Tick span: 2617 ticks
// This is approximately 261.68 ticks per second. It should be 20 ticks per second

--- BEGIN PROFILE DUMP ---

[00] gameRenderer(2617/1) - 57.87%/57.87%
[01] |   level(2617/1) - 85.48%/49.46%
[02] |   |   terrain(2617/1) - 45.79%/22.65%
[03] |   |   |   render_RenderType[solid:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4630/0x00000008016e0ea8@3cc6bfdb]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2617/1) - 39.15%/8.87%
[03] |   |   |   render_RenderType[cutout:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=false)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4632/0x00000008016e12d8@3c6c7782]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2617/1) - 32.53%/7.37%
[03] |   |   |   render_RenderType[cutout_mipped:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4631/0x00000008016e10c0@59ea4ca5]], no_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, main_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2617/1) - 24.56%/5.56%
[03] |   |   |   unspecified(2617/1) - 3.67%/0.83%
[03] |   |   |   filterempty(7851/3) - 0.08%/0.02%
[02] |   |   translucent(2617/1) - 21.95%/10.86%
[03] |   |   |   render_RenderType[translucent:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4633/0x00000008016e14f0@7aaf260f]], translucent_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, translucent_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2617/1) - 61.21%/6.65%
[03] |   |   |   frostedglass:frostedGlassChunkLayer(2617/1) - 32.56%/3.54%
[04] |   |   |   |   unspecified(2617/1) - 80.90%/2.86%
[04] |   |   |   |   frostedglass:setTextureStateBeforeRender(5234/2) - 19.10%/0.68%
[05] |   |   |   |   |   frostedglass:glCopyTexSubImage2D(5234/2) - 87.27%/0.59%
[05] |   |   |   |   |   unspecified(5234/2) - 12.73%/0.09%
[03] |   |   |   unspecified(2617/1) - 6.12%/0.66%
[03] |   |   |   filterempty(2617/1) - 0.06%/0.01%
[03] |   |   |   translucent_sort(2617/1) - 0.05%/0.01%
[02] |   |   entities(2617/1) - 10.30%/5.09%
[02] |   |   hand(2617/1) - 4.48%/2.22%
[03] |   |   |   unspecified(2617/1) - 73.94%/1.64%
[03] |   |   |   frostedglass:setTextureStateBeforeRender(5234/2) - 26.06%/0.58%
[04] |   |   |   |   frostedglass:glCopyTexSubImage2D(5234/2) - 83.12%/0.48%
[04] |   |   |   |   unspecified(5234/2) - 16.88%/0.10%
[02] |   |   blockentities(2617/1) - 2.90%/1.43%
[02] |   |   string(2617/1) - 2.71%/1.34%
[03] |   |   |   render_RenderType[tripwire:CompositeState[[texture[Optional[minecraft:textures/atlas/blocks.png](blur=false, mipmap=true)], shader[Optional[net.minecraft.client.renderer.RenderStateShard$$Lambda$4668/0x00000008016e5e38@739e76e6]], translucent_transparency, depth_test[<=], cull[true], lightmap[true], overlay[false], no_layering, weather_target, default_texturing, write_mask_state[writeColor=true, writeDepth=true], line_width[1.0]], outlineProperty=affects_outline]](2617/1) - 82.41%/1.10%
[03] |   |   |   unspecified(2617/1) - 17.15%/0.23%
[03] |   |   |   filterempty(2617/1) - 0.44%/0.01%
[02] |   |   sky(2617/1) - 2.44%/1.21%
[02] |   |   particles(2617/1) - 2.16%/1.07%
[02] |   |   compilechunks(2617/1) - 2.07%/1.02%
[03] |   |   |   populate_chunks_to_compile(2617/1) - 94.23%/0.96%
[03] |   |   |   unspecified(2617/1) - 3.96%/0.04%
[03] |   |   |   upload(2617/1) - 1.20%/0.01%
[03] |   |   |   schedule_async_compile(2617/1) - 0.62%/0.01%
[02] |   |   clear(2617/1) - 1.21%/0.60%
[02] |   |   unspecified(2617/1) - 1.19%/0.59%
[02] |   |   clouds(2617/1) - 0.80%/0.40%
[02] |   |   outline(2617/1) - 0.57%/0.28%
[02] |   |   pick(2617/1) - 0.42%/0.21%
[03] |   |   |   #getEntities 2617/1
[02] |   |   camera(2617/1) - 0.26%/0.13%
[02] |   |   terrain_setup(2617/1) - 0.26%/0.13%
[03] |   |   |   unspecified(2617/1) - 38.11%/0.05%
[03] |   |   |   culling(2617/1) - 28.11%/0.04%
[03] |   |   |   update(2617/1) - 18.21%/0.02%
[03] |   |   |   camera(2617/1) - 9.87%/0.01%
[03] |   |   |   cull(2617/1) - 5.70%/0.01%
[02] |   |   light_updates(2617/1) - 0.13%/0.06%
[02] |   |   lightTex(201/0) - 0.09%/0.04%
[02] |   |   fog(2617/1) - 0.08%/0.04%
[02] |   |   weather(2617/1) - 0.05%/0.03%
[02] |   |   destroyProgress(2617/1) - 0.04%/0.02%
[02] |   |   light_update_queue(2617/1) - 0.02%/0.01%
[02] |   |   forge_render_last(2617/1) - 0.02%/0.01%
[02] |   |   culling(2617/1) - 0.01%/0.01%
[02] |   |   center(2617/1) - 0.01%/0.01%
[02] |   |   captureFrustum(2617/1) - 0.01%/0.01%
[01] |   gui(2617/1) - 14.45%/8.36%
[02] |   |   unspecified(2617/1) - 68.84%/5.75%
[02] |   |   chat(2617/1) - 23.47%/1.96%
[02] |   |   frostedglass:setTextureStateBeforeRender(5234/2) - 7.35%/0.61%
[03] |   |   |   frostedglass:glCopyTexSubImage2D(5234/2) - 85.61%/0.53%
[03] |   |   |   unspecified(5234/2) - 14.39%/0.09%
[02] |   |   forgeHudText(2617/1) - 0.20%/0.02%
[02] |   |   bossHealth(2617/1) - 0.11%/0.01%
[02] |   |   selectedItemName(2617/1) - 0.04%/0.00%
[01] |   unspecified(2617/1) - 0.07%/0.04%
[00] updateDisplay(2617/1) - 34.24%/34.24%
[00] tick(2617/1) - 4.86%/4.86%
[01] |   #clientTick 202/0
[01] |   level(202/0) - 70.69%/3.43%
[02] |   |   entities(202/0) - 94.33%/3.24%
[03] |   |   |   minecraft:zombie(4761/2) - 10.99%/0.36%
[04] |   |   |   |   unspecified(4761/2) - 47.57%/0.17%
[04] |   |   |   |   entityBaseTick(4761/2) - 14.41%/0.05%
[04] |   |   |   |   livingEntityBaseTick(4761/2) - 10.89%/0.04%
[04] |   |   |   |   push(4761/2) - 9.56%/0.03%
[05] |   |   |   |   |   #getEntities 4761/1
[04] |   |   |   |   freezing(4761/2) - 5.49%/0.02%
[04] |   |   |   |   headTurn(4761/2) - 2.67%/0.01%
[04] |   |   |   |   travel(4761/2) - 2.08%/0.01%
[04] |   |   |   |   mobBaseTick(4761/2) - 2.04%/0.01%
[04] |   |   |   |   ai(4761/2) - 1.51%/0.01%
[04] |   |   |   |   looting(4761/2) - 1.31%/0.00%
[04] |   |   |   |   rangeChecks(4761/2) - 1.24%/0.00%
[04] |   |   |   |   jump(4761/2) - 1.23%/0.00%
[03] |   |   |   minecraft:creeper(3663/1) - 8.98%/0.29%
[04] |   |   |   |   unspecified(3663/1) - 51.02%/0.15%
[04] |   |   |   |   entityBaseTick(3663/1) - 12.13%/0.04%
[04] |   |   |   |   push(3663/1) - 9.68%/0.03%
[05] |   |   |   |   |   #getEntities 3663/1
[04] |   |   |   |   livingEntityBaseTick(3663/1) - 9.37%/0.03%
[04] |   |   |   |   freezing(3663/1) - 6.00%/0.02%
[04] |   |   |   |   headTurn(3663/1) - 2.53%/0.01%
[04] |   |   |   |   travel(3663/1) - 2.07%/0.01%
[04] |   |   |   |   mobBaseTick(3663/1) - 1.77%/0.01%
[04] |   |   |   |   ai(3663/1) - 1.75%/0.01%
[04] |   |   |   |   looting(3663/1) - 1.29%/0.00%
[04] |   |   |   |   jump(3663/1) - 1.21%/0.00%
[04] |   |   |   |   rangeChecks(3663/1) - 1.18%/0.00%
[03] |   |   |   minecraft:cow(3838/1) - 8.94%/0.29%
[04] |   |   |   |   unspecified(3838/1) - 41.56%/0.12%
[04] |   |   |   |   entityBaseTick(3838/1) - 21.02%/0.06%
[04] |   |   |   |   livingEntityBaseTick(3838/1) - 11.48%/0.03%
[04] |   |   |   |   push(3838/1) - 9.13%/0.03%
[05] |   |   |   |   |   #getEntities 3838/1
[04] |   |   |   |   freezing(3838/1) - 4.77%/0.01%
[04] |   |   |   |   headTurn(3838/1) - 2.64%/0.01%
[04] |   |   |   |   travel(3838/1) - 2.14%/0.01%
[04] |   |   |   |   mobBaseTick(3838/1) - 2.06%/0.01%
[04] |   |   |   |   ai(3838/1) - 1.46%/0.00%
[04] |   |   |   |   looting(3838/1) - 1.27%/0.00%
[04] |   |   |   |   rangeChecks(3838/1) - 1.24%/0.00%
[04] |   |   |   |   jump(3838/1) - 1.23%/0.00%
[03] |   |   |   minecraft:skeleton(3631/1) - 8.91%/0.29%
[04] |   |   |   |   unspecified(3631/1) - 46.13%/0.13%
[04] |   |   |   |   entityBaseTick(3631/1) - 15.00%/0.04%
[04] |   |   |   |   livingEntityBaseTick(3631/1) - 11.21%/0.03%
[04] |   |   |   |   push(3631/1) - 9.77%/0.03%
[05] |   |   |   |   |   #getEntities 3631/1
[04] |   |   |   |   freezing(3631/1) - 6.08%/0.02%
[04] |   |   |   |   headTurn(3631/1) - 2.51%/0.01%
[04] |   |   |   |   travel(3631/1) - 2.06%/0.01%
[04] |   |   |   |   mobBaseTick(3631/1) - 2.02%/0.01%
[04] |   |   |   |   ai(3631/1) - 1.47%/0.00%
[04] |   |   |   |   looting(3631/1) - 1.32%/0.00%
[04] |   |   |   |   rangeChecks(3631/1) - 1.22%/0.00%
[04] |   |   |   |   jump(3631/1) - 1.19%/0.00%
[03] |   |   |   minecraft:pig(3636/1) - 8.31%/0.27%
[04] |   |   |   |   unspecified(3636/1) - 43.59%/0.12%
[04] |   |   |   |   entityBaseTick(3636/1) - 16.57%/0.04%
[04] |   |   |   |   livingEntityBaseTick(3636/1) - 11.71%/0.03%
[04] |   |   |   |   push(3636/1) - 9.18%/0.02%
[05] |   |   |   |   |   #getEntities 3636/1
[04] |   |   |   |   freezing(3636/1) - 5.82%/0.02%
[04] |   |   |   |   headTurn(3636/1) - 2.69%/0.01%
[04] |   |   |   |   travel(3636/1) - 2.67%/0.01%
[04] |   |   |   |   mobBaseTick(3636/1) - 2.12%/0.01%
[04] |   |   |   |   ai(3636/1) - 1.54%/0.00%
[04] |   |   |   |   jump(3636/1) - 1.49%/0.00%
[04] |   |   |   |   looting(3636/1) - 1.32%/0.00%
[04] |   |   |   |   rangeChecks(3636/1) - 1.29%/0.00%
[03] |   |   |   minecraft:chicken(2828/1) - 6.41%/0.21%
[04] |   |   |   |   unspecified(2828/1) - 45.94%/0.10%
[04] |   |   |   |   entityBaseTick(2828/1) - 13.75%/0.03%
[04] |   |   |   |   livingEntityBaseTick(2828/1) - 11.59%/0.02%
[04] |   |   |   |   push(2828/1) - 10.49%/0.02%
[05] |   |   |   |   |   #getEntities 2828/1
[04] |   |   |   |   freezing(2828/1) - 5.72%/0.01%
[04] |   |   |   |   headTurn(2828/1) - 2.66%/0.01%
[04] |   |   |   |   mobBaseTick(2828/1) - 2.27%/0.00%
[04] |   |   |   |   travel(2828/1) - 2.15%/0.00%
[04] |   |   |   |   ai(2828/1) - 1.54%/0.00%
[04] |   |   |   |   looting(2828/1) - 1.31%/0.00%
[04] |   |   |   |   rangeChecks(2828/1) - 1.29%/0.00%
[04] |   |   |   |   jump(2828/1) - 1.28%/0.00%
[03] |   |   |   unspecified(202/0) - 5.94%/0.19%
[03] |   |   |   minecraft:squid(1414/1) - 5.77%/0.19%
[04] |   |   |   |   unspecified(1414/1) - 35.04%/0.07%
[04] |   |   |   |   travel(1414/1) - 23.93%/0.04%
[05] |   |   |   |   |   rest(1414/1) - 52.76%/0.02%
[05] |   |   |   |   |   move(1414/1) - 26.53%/0.01%
[06] |   |   |   |   |   |   #getEntities 1414/0
[05] |   |   |   |   |   unspecified(1414/1) - 20.71%/0.01%
[04] |   |   |   |   entityBaseTick(1414/1) - 18.78%/0.04%
[04] |   |   |   |   livingEntityBaseTick(1414/1) - 9.10%/0.02%
[04] |   |   |   |   push(1414/1) - 4.30%/0.01%
[05] |   |   |   |   |   #getEntities 1414/0
[04] |   |   |   |   freezing(1414/1) - 2.48%/0.00%
[04] |   |   |   |   headTurn(1414/1) - 1.71%/0.00%
[04] |   |   |   |   mobBaseTick(1414/1) - 1.33%/0.00%
[04] |   |   |   |   ai(1414/1) - 1.01%/0.00%
[04] |   |   |   |   looting(1414/1) - 0.83%/0.00%
[04] |   |   |   |   rangeChecks(1414/1) - 0.76%/0.00%
[04] |   |   |   |   jump(1414/1) - 0.73%/0.00%
[03] |   |   |   minecraft:player(202/0) - 5.41%/0.18%
[04] |   |   |   |   #getEntities 1010/0
[04] |   |   |   |   unspecified(202/0) - 66.84%/0.12%
[04] |   |   |   |   travel(202/0) - 19.44%/0.03%
[05] |   |   |   |   |   rest(202/0) - 34.70%/0.01%
[05] |   |   |   |   |   unspecified(202/0) - 33.93%/0.01%
[05] |   |   |   |   |   move(202/0) - 31.37%/0.01%
[06] |   |   |   |   |   |   #getEntities 202/0
[04] |   |   |   |   livingEntityBaseTick(202/0) - 4.30%/0.01%
[04] |   |   |   |   entityBaseTick(202/0) - 3.74%/0.01%
[04] |   |   |   |   ai(202/0) - 2.34%/0.00%
[05] |   |   |   |   |   unspecified(202/0) - 66.20%/0.00%
[05] |   |   |   |   |   newAi(202/0) - 33.80%/0.00%
[04] |   |   |   |   push(202/0) - 1.61%/0.00%
[05] |   |   |   |   |   #getEntities 202/0
[04] |   |   |   |   freezing(202/0) - 0.73%/0.00%
[04] |   |   |   |   headTurn(202/0) - 0.65%/0.00%
[04] |   |   |   |   rangeChecks(202/0) - 0.21%/0.00%
[04] |   |   |   |   jump(202/0) - 0.15%/0.00%
[03] |   |   |   minecraft:glow_squid(1099/0) - 4.70%/0.15%
[04] |   |   |   |   unspecified(1099/0) - 44.88%/0.07%
[04] |   |   |   |   travel(1099/0) - 22.47%/0.03%
[05] |   |   |   |   |   rest(1099/0) - 50.53%/0.02%
[05] |   |   |   |   |   move(1099/0) - 27.62%/0.01%
[06] |   |   |   |   |   |   #getEntities 1099/0
[05] |   |   |   |   |   unspecified(1099/0) - 21.85%/0.01%
[04] |   |   |   |   entityBaseTick(1099/0) - 13.02%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1099/0) - 7.07%/0.01%
[04] |   |   |   |   push(1099/0) - 3.96%/0.01%
[05] |   |   |   |   |   #getEntities 1099/0
[04] |   |   |   |   freezing(1099/0) - 2.41%/0.00%
[04] |   |   |   |   headTurn(1099/0) - 1.69%/0.00%
[04] |   |   |   |   mobBaseTick(1099/0) - 1.25%/0.00%
[04] |   |   |   |   ai(1099/0) - 1.00%/0.00%
[04] |   |   |   |   rangeChecks(1099/0) - 0.78%/0.00%
[04] |   |   |   |   looting(1099/0) - 0.75%/0.00%
[04] |   |   |   |   jump(1099/0) - 0.73%/0.00%
[03] |   |   |   minecraft:bat(2408/1) - 4.66%/0.15%
[04] |   |   |   |   unspecified(2408/1) - 50.75%/0.08%
[04] |   |   |   |   livingEntityBaseTick(2408/1) - 13.72%/0.02%
[04] |   |   |   |   entityBaseTick(2408/1) - 13.31%/0.02%
[04] |   |   |   |   freezing(2408/1) - 6.09%/0.01%
[04] |   |   |   |   headTurn(2408/1) - 3.13%/0.00%
[04] |   |   |   |   mobBaseTick(2408/1) - 2.50%/0.00%
[04] |   |   |   |   travel(2408/1) - 2.39%/0.00%
[04] |   |   |   |   push(2408/1) - 1.93%/0.00%
[04] |   |   |   |   ai(2408/1) - 1.72%/0.00%
[04] |   |   |   |   rangeChecks(2408/1) - 1.53%/0.00%
[04] |   |   |   |   jump(2408/1) - 1.49%/0.00%
[04] |   |   |   |   looting(2408/1) - 1.45%/0.00%
[03] |   |   |   minecraft:drowned(1212/0) - 3.86%/0.12%
[04] |   |   |   |   unspecified(1212/0) - 36.21%/0.05%
[04] |   |   |   |   entityBaseTick(1212/0) - 34.51%/0.04%
[04] |   |   |   |   livingEntityBaseTick(1212/0) - 9.00%/0.01%
[04] |   |   |   |   push(1212/0) - 6.06%/0.01%
[05] |   |   |   |   |   #getEntities 1212/0
[04] |   |   |   |   freezing(1212/0) - 5.19%/0.01%
[04] |   |   |   |   headTurn(1212/0) - 1.94%/0.00%
[04] |   |   |   |   travel(1212/0) - 1.72%/0.00%
[04] |   |   |   |   mobBaseTick(1212/0) - 1.60%/0.00%
[04] |   |   |   |   ai(1212/0) - 1.11%/0.00%
[04] |   |   |   |   rangeChecks(1212/0) - 0.92%/0.00%
[04] |   |   |   |   looting(1212/0) - 0.88%/0.00%
[04] |   |   |   |   jump(1212/0) - 0.88%/0.00%
[03] |   |   |   minecraft:sheep(1414/1) - 3.81%/0.12%
[04] |   |   |   |   unspecified(1414/1) - 43.53%/0.05%
[04] |   |   |   |   entityBaseTick(1414/1) - 19.59%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1414/1) - 9.98%/0.01%
[04] |   |   |   |   push(1414/1) - 9.67%/0.01%
[05] |   |   |   |   |   #getEntities 1414/0
[04] |   |   |   |   freezing(1414/1) - 6.03%/0.01%
[04] |   |   |   |   headTurn(1414/1) - 2.28%/0.00%
[04] |   |   |   |   travel(1414/1) - 2.18%/0.00%
[04] |   |   |   |   mobBaseTick(1414/1) - 1.82%/0.00%
[04] |   |   |   |   ai(1414/1) - 1.37%/0.00%
[04] |   |   |   |   looting(1414/1) - 1.32%/0.00%
[04] |   |   |   |   rangeChecks(1414/1) - 1.11%/0.00%
[04] |   |   |   |   jump(1414/1) - 1.11%/0.00%
[03] |   |   |   minecraft:spider(1414/1) - 3.75%/0.12%
[04] |   |   |   |   unspecified(1414/1) - 46.45%/0.06%
[04] |   |   |   |   entityBaseTick(1414/1) - 15.31%/0.02%
[04] |   |   |   |   livingEntityBaseTick(1414/1) - 12.33%/0.01%
[04] |   |   |   |   push(1414/1) - 9.71%/0.01%
[05] |   |   |   |   |   #getEntities 1414/0
[04] |   |   |   |   freezing(1414/1) - 5.21%/0.01%
[04] |   |   |   |   headTurn(1414/1) - 2.46%/0.00%
[04] |   |   |   |   mobBaseTick(1414/1) - 1.84%/0.00%
[04] |   |   |   |   travel(1414/1) - 1.84%/0.00%
[04] |   |   |   |   ai(1414/1) - 1.34%/0.00%
[04] |   |   |   |   looting(1414/1) - 1.24%/0.00%
[04] |   |   |   |   jump(1414/1) - 1.13%/0.00%
[04] |   |   |   |   rangeChecks(1414/1) - 1.12%/0.00%
[03] |   |   |   minecraft:enderman(808/0) - 2.66%/0.09%
[04] |   |   |   |   unspecified(808/0) - 57.61%/0.05%
[04] |   |   |   |   entityBaseTick(808/0) - 11.22%/0.01%
[04] |   |   |   |   push(808/0) - 9.18%/0.01%
[05] |   |   |   |   |   #getEntities 808/0
[04] |   |   |   |   livingEntityBaseTick(808/0) - 8.17%/0.01%
[04] |   |   |   |   freezing(808/0) - 4.55%/0.00%
[04] |   |   |   |   headTurn(808/0) - 2.02%/0.00%
[04] |   |   |   |   mobBaseTick(808/0) - 1.68%/0.00%
[04] |   |   |   |   travel(808/0) - 1.65%/0.00%
[04] |   |   |   |   ai(808/0) - 1.17%/0.00%
[04] |   |   |   |   looting(808/0) - 0.93%/0.00%
[04] |   |   |   |   jump(808/0) - 0.91%/0.00%
[04] |   |   |   |   rangeChecks(808/0) - 0.90%/0.00%
[03] |   |   |   minecraft:horse(808/0) - 2.46%/0.08%
[04] |   |   |   |   unspecified(808/0) - 42.87%/0.03%
[04] |   |   |   |   entityBaseTick(808/0) - 19.76%/0.02%
[04] |   |   |   |   livingEntityBaseTick(808/0) - 10.53%/0.01%
[04] |   |   |   |   push(808/0) - 10.13%/0.01%
[05] |   |   |   |   |   #getEntities 808/0
[04] |   |   |   |   freezing(808/0) - 4.99%/0.00%
[04] |   |   |   |   travel(808/0) - 2.75%/0.00%
[04] |   |   |   |   ai(808/0) - 2.40%/0.00%
[04] |   |   |   |   headTurn(808/0) - 2.02%/0.00%
[04] |   |   |   |   mobBaseTick(808/0) - 1.51%/0.00%
[04] |   |   |   |   jump(808/0) - 1.03%/0.00%
[04] |   |   |   |   looting(808/0) - 1.02%/0.00%
[04] |   |   |   |   rangeChecks(808/0) - 0.99%/0.00%
[03] |   |   |   minecraft:item(1414/1) - 1.74%/0.06%
[04] |   |   |   |   unspecified(1414/1) - 37.89%/0.02%
[04] |   |   |   |   move(353/0) - 32.47%/0.02%
[05] |   |   |   |   |   #getEntities 353/0
[04] |   |   |   |   entityBaseTick(1414/1) - 19.17%/0.01%
[04] |   |   |   |   rest(353/0) - 10.46%/0.01%
[03] |   |   |   minecraft:zombie_villager(294/0) - 0.86%/0.03%
[04] |   |   |   |   unspecified(294/0) - 57.04%/0.02%
[04] |   |   |   |   push(294/0) - 10.69%/0.00%
[05] |   |   |   |   |   #getEntities 294/0
[04] |   |   |   |   entityBaseTick(294/0) - 9.68%/0.00%
[04] |   |   |   |   livingEntityBaseTick(294/0) - 8.15%/0.00%
[04] |   |   |   |   freezing(294/0) - 3.98%/0.00%
[04] |   |   |   |   headTurn(294/0) - 2.28%/0.00%
[04] |   |   |   |   travel(294/0) - 2.05%/0.00%
[04] |   |   |   |   mobBaseTick(294/0) - 1.55%/0.00%
[04] |   |   |   |   ai(294/0) - 1.43%/0.00%
[04] |   |   |   |   jump(294/0) - 1.08%/0.00%
[04] |   |   |   |   looting(294/0) - 1.05%/0.00%
[04] |   |   |   |   rangeChecks(294/0) - 1.02%/0.00%
[03] |   |   |   minecraft:armor_stand(202/0) - 0.71%/0.02%
[04] |   |   |   |   unspecified(202/0) - 49.56%/0.01%
[04] |   |   |   |   push(202/0) - 17.46%/0.00%
[05] |   |   |   |   |   #getEntities 202/0
[04] |   |   |   |   entityBaseTick(202/0) - 9.58%/0.00%
[04] |   |   |   |   livingEntityBaseTick(202/0) - 7.61%/0.00%
[04] |   |   |   |   travel(202/0) - 5.25%/0.00%
[04] |   |   |   |   freezing(202/0) - 4.39%/0.00%
[04] |   |   |   |   headTurn(202/0) - 2.86%/0.00%
[04] |   |   |   |   ai(202/0) - 1.38%/0.00%
[04] |   |   |   |   rangeChecks(202/0) - 0.99%/0.00%
[04] |   |   |   |   jump(202/0) - 0.91%/0.00%
[03] |   |   |   minecraft:witch(202/0) - 0.68%/0.02%
[04] |   |   |   |   unspecified(202/0) - 52.99%/0.01%
[04] |   |   |   |   push(202/0) - 13.02%/0.00%
[05] |   |   |   |   |   #getEntities 202/0
[04] |   |   |   |   entityBaseTick(202/0) - 12.63%/0.00%
[04] |   |   |   |   livingEntityBaseTick(202/0) - 8.12%/0.00%
[04] |   |   |   |   freezing(202/0) - 3.45%/0.00%
[04] |   |   |   |   travel(202/0) - 2.28%/0.00%
[04] |   |   |   |   headTurn(202/0) - 2.25%/0.00%
[04] |   |   |   |   mobBaseTick(202/0) - 1.36%/0.00%
[04] |   |   |   |   ai(202/0) - 1.16%/0.00%
[04] |   |   |   |   jump(202/0) - 0.94%/0.00%
[04] |   |   |   |   rangeChecks(202/0) - 0.92%/0.00%
[04] |   |   |   |   looting(202/0) - 0.89%/0.00%
[03] |   |   |   minecraft:chest_minecart(2020/1) - 0.45%/0.01%
[02] |   |   blockEntities(202/0) - 3.74%/0.13%
[03] |   |   |   unspecified(202/0) - 57.58%/0.07%
[03] |   |   |   minecraft:mob_spawner(5858/2) - 21.42%/0.03%
[03] |   |   |   minecraft:chest(6666/3) - 21.00%/0.03%
[02] |   |   unspecified(202/0) - 1.90%/0.07%
[02] |   |   blocks(202/0) - 0.04%/0.00%
[01] |   textures(202/0) - 13.28%/0.64%
[01] |   animateTick(202/0) - 12.31%/0.60%
[01] |   particles(202/0) - 1.77%/0.09%
[02] |   |   PARTICLE_SHEET_OPAQUE(202/0) - 57.39%/0.05%
[02] |   |   PARTICLE_SHEET_TRANSLUCENT(202/0) - 23.18%/0.02%
[02] |   |   unspecified(202/0) - 19.44%/0.02%
[01] |   unspecified(2617/1) - 0.57%/0.03%
[01] |   gameMode(202/0) - 0.37%/0.02%
[01] |   pick(202/0) - 0.36%/0.02%
[02] |   |   #getEntities 202/0
[01] |   gameRenderer(202/0) - 0.23%/0.01%
[01] |   gui(202/0) - 0.21%/0.01%
[01] |   Keybindings(202/0) - 0.14%/0.01%
[01] |   keyboard(202/0) - 0.04%/0.00%
[01] |   levelRenderer(202/0) - 0.03%/0.00%
[00] unspecified(2617/1) - 1.66%/1.66%
[00] render(2617/1) - 0.64%/0.64%
[01] |   unspecified(2617/1) - 98.67%/0.63%
[01] |   display(2617/1) - 1.33%/0.01%
[00] blit(2617/1) - 0.49%/0.49%
[00] sound(2617/1) - 0.13%/0.13%
[00] yield(2617/1) - 0.06%/0.06%
[00] scheduledExecutables(2617/1) - 0.04%/0.04%
[01] |   unspecified(2617/1) - 97.37%/0.04%
[01] |   queueCheckLight(1/0) - 2.63%/0.00%
[00] toasts(2617/1) - 0.01%/0.01%
[00] fpsUpdate(2617/1) - 0.01%/0.01%
--- END PROFILE DUMP ---

--- BEGIN COUNTER DUMP ---

-- Counter: clientTick --
[00] root total:0/202 average: 0/0
[01] |   tick total:202/202 average: 0/0


-- Counter: getEntities --
[00] root total:0/38323 average: 0/14
[01] |   tick total:0/35706 average: 0/13
[02] |   |   level total:0/35504 average: 0/13
[03] |   |   |   entities total:0/35504 average: 0/13
[04] |   |   |   |   minecraft:zombie total:0/4761 average: 0/1
[05] |   |   |   |   |   push total:4761/4761 average: 1/1
[04] |   |   |   |   minecraft:cow total:0/3838 average: 0/1
[05] |   |   |   |   |   push total:3838/3838 average: 1/1
[04] |   |   |   |   minecraft:creeper total:0/3663 average: 0/1
[05] |   |   |   |   |   push total:3663/3663 average: 1/1
[04] |   |   |   |   minecraft:pig total:0/3636 average: 0/1
[05] |   |   |   |   |   push total:3636/3636 average: 1/1
[04] |   |   |   |   minecraft:skeleton total:0/3631 average: 0/1
[05] |   |   |   |   |   push total:3631/3631 average: 1/1
[04] |   |   |   |   minecraft:squid total:0/2828 average: 0/1
[05] |   |   |   |   |   travel total:0/1414 average: 0/0
[06] |   |   |   |   |   |   move total:1414/1414 average: 0/0
[05] |   |   |   |   |   push total:1414/1414 average: 0/0
[04] |   |   |   |   minecraft:chicken total:0/2828 average: 0/1
[05] |   |   |   |   |   push total:2828/2828 average: 1/1
[04] |   |   |   |   minecraft:glow_squid total:0/2198 average: 0/0
[05] |   |   |   |   |   travel total:0/1099 average: 0/0
[06] |   |   |   |   |   |   move total:1099/1099 average: 0/0
[05] |   |   |   |   |   push total:1099/1099 average: 0/0
[04] |   |   |   |   minecraft:player total:1010/1414 average: 0/0
[05] |   |   |   |   |   travel total:0/202 average: 0/0
[06] |   |   |   |   |   |   move total:202/202 average: 0/0
[05] |   |   |   |   |   push total:202/202 average: 0/0
[04] |   |   |   |   minecraft:sheep total:0/1414 average: 0/0
[05] |   |   |   |   |   push total:1414/1414 average: 0/0
[04] |   |   |   |   minecraft:spider total:0/1414 average: 0/0
[05] |   |   |   |   |   push total:1414/1414 average: 0/0
[04] |   |   |   |   minecraft:drowned total:0/1212 average: 0/0
[05] |   |   |   |   |   push total:1212/1212 average: 0/0
[04] |   |   |   |   minecraft:enderman total:0/808 average: 0/0
[05] |   |   |   |   |   push total:808/808 average: 0/0
[04] |   |   |   |   minecraft:horse total:0/808 average: 0/0
[05] |   |   |   |   |   push total:808/808 average: 0/0
[04] |   |   |   |   minecraft:item total:0/353 average: 0/0
[05] |   |   |   |   |   move total:353/353 average: 0/0
[04] |   |   |   |   minecraft:zombie_villager total:0/294 average: 0/0
[05] |   |   |   |   |   push total:294/294 average: 0/0
[04] |   |   |   |   minecraft:witch total:0/202 average: 0/0
[05] |   |   |   |   |   push total:202/202 average: 0/0
[04] |   |   |   |   minecraft:armor_stand total:0/202 average: 0/0
[05] |   |   |   |   |   push total:202/202 average: 0/0
[02] |   |   pick total:202/202 average: 0/0
[01] |   gameRenderer total:0/2617 average: 0/1
[02] |   |   level total:0/2617 average: 0/1
[03] |   |   |   pick total:2617/2617 average: 1/1


--- END COUNTER DUMP ---


```

</details>